### PR TITLE
Update MessengerScreen.js

### DIFF
--- a/client/app/screens/MessengerScreen.js
+++ b/client/app/screens/MessengerScreen.js
@@ -185,7 +185,7 @@ const MessengerScreen = props => {
         // </View>
 
         <View style={{ flex: 1 }}>
-            <KeyboardAvoidingView behavior="" style={styles.keyboard} keyboardVerticalOffset={keyboardVerticalOffset}>
+            <KeyboardAvoidingView behavior="padding" style={styles.keyboard} keyboardVerticalOffset={keyboardVerticalOffset}>
                 <FlatList
                     style={styles.list}
                     data={messages}


### PR DESCRIPTION
"padding" somehow got deleted from line 188, keyboard avoiding view was therefore not working, bottom half of the View would be inaccessible when the kyeboard was triggered.